### PR TITLE
refactor: replace `classnames` w/ `clsx`

### DIFF
--- a/packages/webassembly-playground/package.json
+++ b/packages/webassembly-playground/package.json
@@ -39,7 +39,7 @@
     "webpack-merge": "^5.10.0"
   },
   "dependencies": {
-    "classnames": "^2.5.1",
+    "clsx": "^2.1.1",
     "console-feed": "^3.6.0",
     "jotai": "^2.10.3",
     "monaco-editor": "^0.52.0",

--- a/packages/webassembly-playground/src/ui/Dropdown.tsx
+++ b/packages/webassembly-playground/src/ui/Dropdown.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
-import cx from "classnames";
+import cx from "clsx";
 
 type DropdownProps = {
   entry: ReactNode;

--- a/packages/webassembly-playground/src/ui/UtilPanel.tsx
+++ b/packages/webassembly-playground/src/ui/UtilPanel.tsx
@@ -1,5 +1,5 @@
 import { useAtom, useAtomValue } from "jotai";
-import cx from "classnames";
+import cx from "clsx";
 import { Console } from "console-feed";
 
 import {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,9 @@ importers:
 
   packages/webassembly-playground:
     dependencies:
-      classnames:
-        specifier: ^2.5.1
-        version: 2.5.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       console-feed:
         specifier: ^3.6.0
         version: 3.6.0(jquery@3.7.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1170,9 +1170,6 @@ packages:
     resolution: {integrity: sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==}
     engines: {node: '>= 0.10'}
 
-  classnames@2.5.1:
-    resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
-
   clean-css@5.3.3:
     resolution: {integrity: sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==}
     engines: {node: '>= 10.0'}
@@ -1187,6 +1184,10 @@ packages:
 
   clone-deep@4.0.1:
     resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
+    engines: {node: '>=6'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
   colorette@2.0.20:
@@ -4252,8 +4253,6 @@ snapshots:
       inherits: 2.0.4
       safe-buffer: 5.2.1
 
-  classnames@2.5.1: {}
-
   clean-css@5.3.3:
     dependencies:
       source-map: 0.6.1
@@ -4272,6 +4271,8 @@ snapshots:
       is-plain-object: 2.0.4
       kind-of: 6.0.3
       shallow-clone: 3.0.1
+
+  clsx@2.1.1: {}
 
   colorette@2.0.20: {}
 


### PR DESCRIPTION
`clsx` is a drop-in replacement of `classnames`, but is 2x faster and 50% smaller.